### PR TITLE
Jekyll date string workaround

### DIFF
--- a/_posts/2014-01-10-by-election.html
+++ b/_posts/2014-01-10-by-election.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: "Community Liaison By-Election: Winter 2014"
+date_string: "January 10, 2014"
 ---
 <div class="container-fluid">
   <div class= "col-md-8 col-md-offset-2">

--- a/_posts/2014-03-06-agm-results.html
+++ b/_posts/2014-03-06-agm-results.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: "SOCIS Annual General Meeting Election 2014"
+date_string: "March 6, 2014"
 ---
 <div class="container-fluid">
   <div class= "col-md-8 col-md-offset-2">

--- a/news/index.html
+++ b/news/index.html
@@ -7,7 +7,7 @@ layout: default
     {% for post in site.posts %}
     <article>
       <h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
-      <p>{{ page.date | date: '%B %d, %Y' }}</p>
+      <p>{{ page.date_string }}</p>
     </article>
     <hr>
     {% endfor %}


### PR DESCRIPTION
Date string formatting didn't seem to be working. This should be a functional workaround though
