### PR TITLE
Add link to Hacktoberfest page from homepage

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,6 +12,7 @@
         </div>
         <div class="collapse navbar-collapse" id="main-navbar-collapse">
           <ul class="nav navbar-nav navbar-right">
+            <li><a class="hacktoberfest" href="/hacktoberfest/">Hacktoberfest</a></li>
             <li><a href="/events/">Events</a></li>
             <li><a href="/gcc/">GCC</a></li>
             <li><a href="/roboticon/">Roboticon</a></li>

--- a/css/main.scss
+++ b/css/main.scss
@@ -11,6 +11,7 @@ $guelph-dark-red: #660000;
 $guelph-light-red: #990100;
 $guelph-yellow: #FDC82F;
 $guelph-orange: #FD9800;
+$guelph-hacktoberfest: #FF00AA;
 $white: #FFF;
 $black: #000;
 $dark-grey: #21201c;
@@ -95,8 +96,13 @@ header {
         -webkit-transition:color .2s ease-in;
     }
     a:hover {
-        color: $guelph-yellow;
+        color: $guelph-yellow !important;
         background-color: transparent !important;
+    }
+
+    // Special events
+    a.hacktoberfest {
+        color: $guelph-hacktoberfest;
     }
 
     .navbar {


### PR DESCRIPTION
- Adds a link to the Hacktoberfest page that Dema created in #96 to the homepage
- Made the link hover colour in the `:hover` pseudo-class of the `header a` class to be `!important`, so that the hover colour will still be displayed even for special event links, which subclass from `header a`.