### PR TITLE
Removed the specified pages from the navbar

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,10 +13,6 @@
         <div class="collapse navbar-collapse" id="main-navbar-collapse">
           <ul class="nav navbar-nav navbar-right">
             <li><a href="/events/">Events</a></li>
-            <li><a href="/gcc/">GCC</a></li>
-            <li><a href="/roboticon/">Roboticon</a></li>
-            <li><a href="/cusec/">CUSEC</a></li>
-            <li><a href="/csgames/">CS Games</a></li>
             <li><a href="/about/">About</a></li>
           </ul>
         </div>


### PR DESCRIPTION
Resolved issue #132: "Remove GCC, Roboticon, CSGames, and CUSEC from the header".