### PR TITLE
DNM: Remove election alert.

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -159,12 +159,6 @@ footer {
 /*===================================================*/
 /* Homepage styles */
 /*===================================================*/
-.alert {
-    margin-bottom: 0;
-}
-.alert-primary {
-    background-color: $guelph-yellow;
-}
 
 .jumbotron {
     background-image: url(/img/reynolds.jpg);

--- a/index.html
+++ b/index.html
@@ -3,13 +3,6 @@ layout: default-legacy
 background: "white"
 ---
 
-<div class="alert alert-primary" role="alert">
-  <div class="container">
-  <div class="col-md-8 col-md-offset-2">
-    The SOCIS 2021/22 Executive Elections are now live! <a href="https://gryphlife.uoguelph.ca/organization/socis">Vote by Thurs, Apr 15 @ 5:30pm ET</a>.
-  </div>
-  </div>
-</div>
 <div class="jumbotron">
   <div class="container">
     <div class="col-sm-5">


### PR DESCRIPTION
Reverts #134. Merge this during our exec meeting on Apr 15, after the election concludes.