### PR TITLE
Removed specified items from header (fixed)

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,10 +14,6 @@
           <ul class="nav navbar-nav navbar-right">
             <li><a href="/events/">Events</a></li>
             <li><a href="/clubs/">Clubs</a></li>
-            <li><a href="/gcc/">GCC</a></li>
-            <li><a href="/roboticon/">Roboticon</a></li>
-            <li><a href="/cusec/">CUSEC</a></li>
-            <li><a href="/csgames/">CS Games</a></li>
             <li><a href="/about/">About</a></li>
           </ul>
         </div>


### PR DESCRIPTION
Resolved Issue #132: "Remove GCC, Roboticon, CSGames, and CUSEC from the header". @keeferrourke indicated that I had submitted the pull request incorrectly. I followed the instructions and submitted again. Please let me know if there are any further issues with this pull request.

Thanks,
Dan